### PR TITLE
Add ChemBio AI landing page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,328 @@
+:root {
+  --bg: #05060a;
+  --surface: #0f111a;
+  --surface-2: #151928;
+  --text: #f5f7ff;
+  --muted: #9aa3c2;
+  --accent: #8f9bff;
+  --accent-2: #ff9ad5;
+  --accent-3: #6fffd2;
+  --radius: 20px;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top right, rgba(143, 155, 255, 0.2), transparent 40%),
+    radial-gradient(circle at bottom left, rgba(255, 154, 213, 0.15), transparent 35%),
+    var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+main {
+  width: min(1100px, 90vw);
+  margin: 0 auto;
+  padding-bottom: 4rem;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  gap: 2rem;
+  width: min(1100px, 90vw);
+  margin: 0 auto;
+  padding: 4rem 0 3rem;
+}
+
+.hero__content h1 {
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  margin-bottom: 1rem;
+}
+
+.hero__content .lead {
+  color: var(--muted);
+  margin-bottom: 1.5rem;
+}
+
+.hero__media {
+  position: relative;
+  background: var(--surface);
+  border-radius: 36px;
+  padding: 1.5rem;
+  overflow: hidden;
+  min-height: 320px;
+}
+
+.orb {
+  position: absolute;
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  filter: blur(35px);
+  opacity: 0.6;
+}
+
+.orb--pink {
+  background: var(--accent-2);
+  top: 20px;
+  right: 30px;
+}
+
+.orb--blue {
+  background: var(--accent);
+  bottom: 10px;
+  left: 20px;
+}
+
+.orb--green {
+  background: var(--accent-3);
+  top: 40%;
+  left: 45%;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.8rem;
+  color: var(--accent-3);
+  margin-bottom: 0.5rem;
+}
+
+.newsletter {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.newsletter input,
+.newsletter button,
+.cta__form input,
+.cta__form button,
+.contact__form input,
+.contact__form textarea,
+.contact__form button {
+  font: inherit;
+}
+
+.newsletter input,
+.cta__form input,
+.contact__form input,
+.contact__form textarea {
+  flex: 1;
+  min-width: 200px;
+  padding: 0.85rem 1rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--text);
+}
+
+.newsletter button,
+.cta__form button,
+.contact__form button {
+  background: linear-gradient(135deg, var(--accent-2), var(--accent));
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.8rem;
+  color: #05060a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.newsletter button:hover,
+.cta__form button:hover,
+.contact__form button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 25px rgba(143, 155, 255, 0.3);
+}
+
+.form-feedback {
+  color: var(--accent-3);
+  margin-top: 0.6rem;
+  min-height: 1.2rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.toolbar {
+  margin-top: 2rem;
+  padding: 1.5rem 2rem;
+  background: rgba(21, 25, 40, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 999px;
+  padding: 0.3rem 0.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.search input {
+  background: transparent;
+  border: none;
+  color: var(--text);
+  padding: 0.7rem 0.9rem;
+  width: 230px;
+}
+
+.search input:focus {
+  outline: none;
+}
+
+.search svg {
+  width: 24px;
+  height: 24px;
+  fill: var(--muted);
+}
+
+.grid {
+  margin-top: 2.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  background: rgba(21, 25, 40, 0.85);
+  border-radius: var(--radius);
+  padding: 1.8rem;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.card:hover {
+  border-color: rgba(111, 255, 210, 0.6);
+  transform: translateY(-6px);
+}
+
+.card__icon {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.card ul {
+  padding-left: 1.1rem;
+  color: var(--muted);
+}
+
+.card--hidden {
+  display: none;
+}
+
+.card mark {
+  background: rgba(255, 154, 213, 0.3);
+  color: var(--text);
+}
+
+.cta {
+  margin-top: 3rem;
+  padding: 2.5rem;
+  border-radius: var(--radius);
+  background: linear-gradient(120deg, rgba(255, 154, 213, 0.15), rgba(111, 255, 210, 0.15));
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2rem;
+}
+
+.cta__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  align-items: center;
+}
+
+.contact {
+  margin-top: 3.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  background: rgba(21, 25, 40, 0.9);
+  border-radius: var(--radius);
+  padding: 2.5rem;
+}
+
+.contact__info ul {
+  padding-left: 1rem;
+  color: var(--muted);
+}
+
+.contact__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.contact__form input,
+.contact__form textarea {
+  border-radius: 14px;
+}
+
+footer {
+  width: min(1100px, 90vw);
+  margin: 3rem auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  color: var(--muted);
+}
+
+.back-to-top {
+  color: var(--accent-3);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .newsletter input,
+  .newsletter button,
+  .cta__form input,
+  .cta__form button {
+    width: 100%;
+  }
+
+  .search {
+    width: 100%;
+  }
+
+  .search input {
+    width: 100%;
+  }
+}

--- a/assets/images/lab-network.svg
+++ b/assets/images/lab-network.svg
@@ -1,0 +1,24 @@
+<svg width="320" height="320" viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff8fb1"/>
+      <stop offset="50%" stop-color="#8f9bff"/>
+      <stop offset="100%" stop-color="#6fffd2"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="320" rx="32" fill="#0d111a"/>
+  <g fill="none" stroke="url(#grad)" stroke-width="2" opacity="0.7">
+    <circle cx="160" cy="160" r="120"/>
+    <circle cx="160" cy="160" r="80"/>
+    <circle cx="160" cy="160" r="40"/>
+    <path d="M40 80 Q160 10 280 80"/>
+    <path d="M80 280 Q160 180 240 280"/>
+  </g>
+  <g fill="#f6f8ff">
+    <circle cx="70" cy="120" r="8"/>
+    <circle cx="250" cy="90" r="10"/>
+    <circle cx="220" cy="230" r="6"/>
+    <circle cx="110" cy="240" r="7"/>
+    <circle cx="160" cy="160" r="12" fill="#ffffff"/>
+  </g>
+</svg>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,76 @@
+const yearEl = document.getElementById('year');
+yearEl.textContent = new Date().getFullYear();
+
+const sections = Array.from(document.querySelectorAll('.card'));
+const searchInput = document.getElementById('siteSearch');
+
+const highlight = (text, term) => {
+  if (!term) return text;
+  const regex = new RegExp(`(${term})`, 'gi');
+  return text.replace(regex, '<mark>$1</mark>');
+};
+
+const resetHighlights = () => {
+  sections.forEach(section => {
+    const paragraphs = section.querySelectorAll('p, li, h3');
+    paragraphs.forEach(node => {
+      node.innerHTML = node.textContent;
+    });
+  });
+};
+
+const filterSections = value => {
+  const term = value.trim();
+  resetHighlights();
+  if (!term) {
+    sections.forEach(card => card.classList.remove('card--hidden'));
+    return;
+  }
+
+  sections.forEach(card => {
+    const content = card.innerText.toLowerCase();
+    const match = content.includes(term.toLowerCase());
+    card.classList.toggle('card--hidden', !match);
+
+    if (match) {
+      const nodes = card.querySelectorAll('p, li, h3');
+      nodes.forEach(node => {
+        node.innerHTML = highlight(node.textContent, term);
+      });
+    }
+  });
+};
+
+searchInput.addEventListener('input', event => filterSections(event.target.value));
+
+const fakeSubmit = (formId, feedbackId, successText) => {
+  const form = document.getElementById(formId);
+  const feedback = document.getElementById(feedbackId);
+  form.addEventListener('submit', event => {
+    event.preventDefault();
+    const formData = new FormData(form);
+    const email = formData.get('email') || form.querySelector('input[type="email"]').value;
+    if (!email) {
+      feedback.textContent = 'Please enter a valid email address.';
+      return;
+    }
+    feedback.textContent = 'Saving your preferences...';
+    setTimeout(() => {
+      feedback.textContent = successText.replace('{email}', email);
+      form.reset();
+    }, 800);
+  });
+};
+
+fakeSubmit('newsletterForm', 'newsletterFeedback', 'Thanks {email}! Check your inbox for a confirmation email.');
+fakeSubmit('ctaForm', 'ctaFeedback', 'Welcome aboard, {email}. Expect fresh insights soon.');
+
+const contactForm = document.getElementById('contactForm');
+const contactFeedback = document.getElementById('contactFeedback');
+contactForm.addEventListener('submit', event => {
+  event.preventDefault();
+  const formData = new FormData(contactForm);
+  const name = formData.get('name');
+  contactFeedback.textContent = `Thanks ${name}! I will respond shortly.`;
+  contactForm.reset();
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ChemBio AI Insights</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header class="hero" id="top">
+    <div class="hero__content">
+      <p class="eyebrow">ChemBio AI Insights</p>
+      <h1>Exploring how AI reshapes life sciences and beyond</h1>
+      <p class="lead">From drug discovery to smart farms, stay on top of the latest breakthroughs and practical tips for using AI responsibly.</p>
+      <form class="newsletter" id="newsletterForm">
+        <label class="sr-only" for="newsletterEmail">Subscribe for updates</label>
+        <input type="email" id="newsletterEmail" name="email" placeholder="Enter your email" required />
+        <button type="submit">Subscribe</button>
+      </form>
+      <p class="form-feedback" id="newsletterFeedback" aria-live="polite"></p>
+    </div>
+    <div class="hero__media" aria-hidden="true">
+      <div class="orb orb--pink"></div>
+      <div class="orb orb--blue"></div>
+      <div class="orb orb--green"></div>
+      <img src="assets/images/lab-network.svg" alt="Stylized AI network" />
+    </div>
+  </header>
+
+  <main>
+    <section class="toolbar">
+      <div>
+        <h2>Search the site</h2>
+        <p>Quickly scan through every insight using the search bar.</p>
+      </div>
+      <label class="search" for="siteSearch">
+        <span class="sr-only">Search content</span>
+        <input type="search" id="siteSearch" placeholder="Search use cases, tips, or sectors" />
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15.5 14h-.79l-.28-.27A6.5 6.5 0 1014 15.5l.27.28v.79L20 21.5 21.5 20l-5.5-6zM10 15a5 5 0 110-10 5 5 0 010 10z"/></svg>
+      </label>
+    </section>
+
+    <section class="grid" id="useCases">
+      <article class="card" data-tags="pharma drug discovery ai molecules automation">
+        <div class="card__icon">💊</div>
+        <h3>AI in Pharmaceuticals</h3>
+        <p>Generative molecular design, predictive toxicology, and automated trial matching accelerate the path from target discovery to clinical validation.</p>
+        <ul>
+          <li>Autonomous screening robots pair with vision models to evaluate assays in minutes.</li>
+          <li>Digital twins simulate patient cohorts to reduce the size and cost of trials.</li>
+          <li>Knowledge graphs connect literature, omics data, and EHR evidence in one view.</li>
+        </ul>
+      </article>
+
+      <article class="card" data-tags="agriculture agtech farming crops sustainability sensors">
+        <div class="card__icon">🌾</div>
+        <h3>AI in AgTech</h3>
+        <p>Hyper-local weather predictions, vision-based crop monitoring, and intelligent irrigation make farms resilient and sustainable.</p>
+        <ul>
+          <li>Edge AI drones identify nutrient stress and pests before yield drops.</li>
+          <li>Reinforcement learning keeps greenhouse climates stable while saving energy.</li>
+          <li>Market models help co-ops optimize harvest logistics and pricing.</li>
+        </ul>
+      </article>
+
+      <article class="card" data-tags="laboratory automation robotics quality control computer vision">
+        <div class="card__icon">🧪</div>
+        <h3>AI in Laboratories</h3>
+        <p>Computer-vision powered notebooks, robotic pipetting, and anomaly detection redefine lab safety and reproducibility.</p>
+        <ul>
+          <li>Large language models draft experiment plans from plain-language hypotheses.</li>
+          <li>Real-time monitoring flags plate contamination before reagents are wasted.</li>
+          <li>Predictive maintenance keeps centrifuges, incubators, and freezers healthy.</li>
+        </ul>
+      </article>
+
+      <article class="card" data-tags="tips tools productivity prompting guides">
+        <div class="card__icon">🛠️</div>
+        <h3>AI Tool Tips &amp; Updates</h3>
+        <p>Stay productive with curated guidance for prompts, compliance, and the newest APIs.</p>
+        <ul>
+          <li>Adopt a prompt template library so teams reuse proven workflows.</li>
+          <li>Sandbox automation: run batch experiments safely with audit logs.</li>
+          <li>Monitor model cards to understand changes that impact regulated workloads.</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="cta" id="subscribe">
+      <div>
+        <h2>Subscribe for early insights</h2>
+        <p>Monthly digests, curated datasets, and invite-only AMAs with scientists working at the frontiers of AI.</p>
+      </div>
+      <form class="cta__form" id="ctaForm">
+        <label class="sr-only" for="ctaEmail">Email address</label>
+        <input type="email" id="ctaEmail" placeholder="Email" required />
+        <button type="submit">Join the list</button>
+        <p class="form-feedback" id="ctaFeedback" aria-live="polite"></p>
+      </form>
+    </section>
+
+    <section class="contact" id="contact">
+      <div class="contact__info">
+        <h2>Contact me</h2>
+        <p>Have a collaboration idea or need a custom AI workshop? Drop a message and I’ll get back within 48 hours.</p>
+        <ul>
+          <li><strong>Email:</strong> hello@chembio.ai</li>
+          <li><strong>Location:</strong> Remote-first across Europe &amp; North America</li>
+          <li><strong>Office hours:</strong> Tue–Thu, 9am–3pm CET</li>
+        </ul>
+      </div>
+      <form class="contact__form" id="contactForm">
+        <label for="name">Name</label>
+        <input type="text" id="name" name="name" placeholder="Your full name" required />
+
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" placeholder="Email" required />
+
+        <label for="message">Message</label>
+        <textarea id="message" name="message" rows="5" placeholder="How can I help?" required></textarea>
+
+        <button type="submit">Send message</button>
+        <p class="form-feedback" id="contactFeedback" aria-live="polite"></p>
+      </form>
+    </section>
+  </main>
+
+  <footer>
+    <p>© <span id="year"></span> ChemBio AI Insights · Crafted for GitHub Pages deployment.</p>
+    <a href="#top" class="back-to-top">Back to top ↑</a>
+  </footer>
+
+  <script src="assets/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a responsive ChemBio AI landing page with hero, search, and detailed sector cards
- style the page with a modern neon-dark theme and custom SVG art to make GitHub Pages ready
- include interactive JS for searching, subscriptions, and contact form feedback

## Testing
- python -m http.server 8000

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df4c0310c8323bf7d2be9b3f60872)